### PR TITLE
Change policies to managed policies

### DIFF
--- a/sagemaker_run_notebook/cloudformation-base.yml
+++ b/sagemaker_run_notebook/cloudformation-base.yml
@@ -83,9 +83,9 @@ Resources:
             Action:
               - 'sts:AssumeRole'
   ExecuteNotebookClientPolicy:
-    Type: 'AWS::IAM::Policy'
+    Type: 'AWS::IAM::ManagedPolicy'
     Properties:
-      PolicyName: {"Fn::Join": ["-", ["ExecuteNotebookClient", {"Ref": "AWS::Region"}]]}
+      ManagedPolicyName: {"Fn::Join": ["-", ["ExecuteNotebookClient", {"Ref": "AWS::Region"}]]}
       Roles: 
         - !Ref ExecuteNotebookClientRole
       PolicyDocument:
@@ -151,9 +151,9 @@ Resources:
             Action:
               - 'sts:AssumeRole'
   ExecuteNotebookContainerPolicy:
-    Type: 'AWS::IAM::Policy'
+    Type: 'AWS::IAM::ManagedPolicy'
     Properties:
-      PolicyName: {"Fn::Join": ["-", ["ExecuteNotebookContainerPolicy", {"Ref": "AWS::Region"}]]}
+      ManagedPolicyName: {"Fn::Join": ["-", ["ExecuteNotebookContainerPolicy", {"Ref": "AWS::Region"}]]}
       Roles: 
         - !Ref BasicExecuteNotebookRole
       PolicyDocument:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The docs state "If you're not running with administrative permissions, you should add that policy to the user or role that you're using to invoke and schedule notebooks."
This PR changes the IAM policies to managed policies so that they can actually be attached to different roles.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
