### PR TITLE
Make studio script default to jupyter v1 extension

### DIFF
--- a/scripts/studio/install-run-notebook.sh
+++ b/scripts/studio/install-run-notebook.sh
@@ -1,4 +1,4 @@
-version=0.20.0
+version=0.19.0
 pip install https://github.com/aws-samples/sagemaker-run-notebook/releases/download/v${version}/sagemaker_run_notebook-${version}.tar.gz
 jlpm config set cache-folder /tmp/yarncache
 jupyter lab build --debug --minimize=False


### PR DESCRIPTION
Fixes #40 

*Description of changes:*
Given that SageMaker Studio is still on jupyter v1 it's unclear why we should bump this script's installation version and make it incompatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
