### PR TITLE
Update DIY.md

### DIFF
--- a/DIY.md
+++ b/DIY.md
@@ -157,3 +157,8 @@ Note that times are always in UTC. To see the full rules on times, view the Clou
 [sched]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
 
 When the notebook has run, you can find the jobs with `aws sagemaker list-processing-jobs` and then describe the job and download the notebook as described above.
+
+Few Common conatiners apart from default python -
+
+1. Conda container - run-notebook create-container --base public.ecr.aws/y0o4y9o3/anaconda-pkg-build:latest repository_name
+2. Tensorflow conatiner - run-notebook create-container --base 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.9.1-gpu-py39-cu112-ubuntu20.04-e3 notebook-runner-tensorflow


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I have been using sagemaker-run-notebook for scheduling notebooks at my team. It was not easy to find first of all why my codes from sagemaker was not working using sagemaker-run-notebook. When I realized I had to create custom containers, it was tough to find a working version. These worked for my 2 different usecases, so thought of adding it so it would help people who are also trying to do the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
