### PR TITLE
Fix for JupyterLab plugin issues

### DIFF
--- a/labextension/package.json
+++ b/labextension/package.json
@@ -7,9 +7,9 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/awslabs/sagemaker_run_notebook",
+  "homepage": "https://github.com/aws-samples/sagemaker_run_notebook",
   "bugs": {
-    "url": "https://github.com/awslabs/sagemaker_run_notebook/issues"
+    "url": "https://github.com/aws-samples/sagemaker_run_notebook/issues"
   },
   "license": "Apache-2.0",
   "author": "Amazon Web Services",
@@ -22,7 +22,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/awslabs/sagemaker_run_notebook.git"
+    "url": "https://github.com/aws-samples/sagemaker_run_notebook.git"
   },
   "scripts": {
     "build": "jlpm run build:lib && jlpm run build:labextension:dev",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setuptools.setup(
     description="Schedule notebooks to run using SageMaker processing jobs",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/awslabs/sagemaker-run-notebook",
+    url="https://github.com/aws-samples/sagemaker-run-notebook",
     cmdclass=cmdclass,
     packages=["sagemaker_run_notebook", "sagemaker_run_notebook.server_extension"],
     license="Apache License 2.0",


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-samples/sagemaker-run-notebook/issues/66

*Description of changes:*

The current code doesn't install the JupyterLab extension both in Notebook instances and Studio properly as the `package.json` points to what seems to be an unavailable repo.

This PR updates the Git URLs in the code to this repo to fix the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
